### PR TITLE
Add provider to transaction

### DIFF
--- a/lib/affirm/structs/transaction.rb
+++ b/lib/affirm/structs/transaction.rb
@@ -12,6 +12,15 @@ module Affirm
       attr_accessor :order_id
       attr_accessor :provider_id
       attr_accessor :status
+
+      def provider
+        case provider_id
+        when 1
+          :affirm
+        when 2
+          :katapult
+        end
+      end
     end
   end
 end

--- a/spec/affirm/structs/transaction_spec.rb
+++ b/spec/affirm/structs/transaction_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe Affirm::Struct::Transaction do
+  describe "#provider" do
+    context "when provider_id is 1" do
+      let(:transaction) { Affirm::Struct::Transaction.new(provider_id: 1) }
+      it "returns :affirm" do
+        expect(transaction.provider).to eql :affirm
+      end
+    end
+
+    context "when provider_id is 2" do
+      let(:transaction) { Affirm::Struct::Transaction.new(provider_id: 2) }
+      it "returns :katapult" do
+        expect(transaction.provider).to eql :katapult
+      end
+    end
+
+    context "when provider_id is nil" do
+      let(:transaction) { Affirm::Struct::Transaction.new }
+      it "returns nil" do
+        expect(transaction.provider).to eql nil
+      end
+    end
+
+    context "when provider_id is anything else" do
+      let(:transaction) { Affirm::Struct::Transaction.new(provider_id: 99) }
+      it "returns nil" do
+        expect(transaction.provider).to eql nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Enhancement

Add `Affirm::Struct::Transaction#provider`

## Description

Affirm returns a magic number for the provider used on the platform.

This commit adds a provider method on the transaction to return the proper
name for the provider.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB, RSpec) are passing
